### PR TITLE
[Game] Fix game reset issue and ZeroDivisionError on accuracy

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ class Main:
             if px.btnp(px.KEY_M):
                 self.game_state = "menu"
             if px.btnp(px.KEY_S):
+                self.reset_game()
                 self.game_state = "playing"
         elif self.game_state == "playing":
             self.update_playing()

--- a/source/menu.py
+++ b/source/menu.py
@@ -95,14 +95,13 @@ class Menu:
             "total_successful_shots"
         ] += self.main.successful_shots
         self.main.stats["global_stats"]["total_shots_fired"] += self.main.shots_fired
-        self.main.stats["global_stats"]["average_accuracy"] = round(
-            (
-                self.main.stats["global_stats"]["total_successful_shots"]
-                / self.main.stats["global_stats"]["total_shots_fired"]
-            )
-            * 100,
-            2,
+        accuracy = (
+            self.main.stats["global_stats"]["total_successful_shots"]
+            / self.main.stats["global_stats"]["total_shots_fired"]
+            if self.main.stats["global_stats"]["total_shots_fired"]
+            else 0
         )
+        self.main.stats["global_stats"]["average_accuracy"] = round(accuracy * 100, 2)
 
         with open("data/stats.json", "w") as file:
             json.dump(self.main.stats, file, indent=4)
@@ -148,17 +147,18 @@ class Menu:
         self.game_over_frame_count += 1
         title_y = min(5, -10 + (self.game_over_frame_count // 2))
         px.text(30, title_y, "--- GAME OVER ---", 7)
-
+        accuracy = (
+            self.main.successful_shots / self.main.shots_fired
+            if self.main.shots_fired
+            else 0
+        )
         wave_offset = (self.game_over_frame_count // 5) % 10
         animated_stats = [
             (f"SCORE: {self.main.score} PTS", 20),
             (f"HIGHSCORE: {self.main.stats['records']['highscore']} PTS", 30),
             (f"WAVE: {self.main.wave}", 50),
             (f"HIGHEST WAVE: {self.main.stats['records']['highest_wave_reached']}", 60),
-            (
-                f"ACCURACY: {round((self.main.successful_shots/self.main.shots_fired)* 100, 2)} %",
-                80,
-            ),
+            (f"ACCURACY: {round(accuracy * 100, 2)} %", 80),
             (
                 f"AVERAGE ACCURACY: {self.main.stats['global_stats']['average_accuracy']} %",
                 90,


### PR DESCRIPTION
## Description  
This PR fixes two issues:  
1. ZeroDivisionError occurred when no shots were fired during the game, causing a crash on the Game Over screen.  
2. Game state was not properly resetting when starting a new game from the Rules menu after a Game Over. 

## Why  
- Issue #10: The game crashed due to a division by zero when displaying accuracy.  
- Issue #11: Players were able to continue the previous session when starting from the Rules menu. This was confusing and unintended.  

## Changes

#### Summary  
Game state is now fully reset before starting a new game, even when navigating through menus.  The accuracy calculation now handles division by zero correctly by setting it to `0%` when no shots were fired.  

#### Details  
- **Fix**: Accuracy is now calculated with a check to prevent ZeroDivisionError.
- **Fix**: Added `self.reset_game()` when transitioning from Rules to Game.  

## How to Test  
1. Test the accuracy fix:
   - Start the game.  
   - Do not fire any shots.  
   - Lose the game.  
   - The Game Over screen should show 0% accuracy without crashing.  

2. **Test the game reset fix:**  
   - Start a game and lose (Game Over).  
   - Go to the Rules menu from the main menu.  
   - Start a new game from there.  
   - The new game should be completely reset (score, enemies, bullets, etc.).  

## Related Issues  
- Fixes #10 
- Fixes #11 
